### PR TITLE
run_qemu: make git-qemu argument a path

### DIFF
--- a/parser_generator.m4
+++ b/parser_generator.m4
@@ -34,7 +34,7 @@ exit 11  #)Created by argbash-init v2.9.0
 # ARG_OPTIONAL_BOOLEAN([qmp], , [Open a QMP socket at unix:./run_qemu_qmp], )
 # ARG_OPTIONAL_BOOLEAN([rw], , [Make guest image writeable (remove -snapshot)\n (Note that an image rebuild will lose any changes made via --rw)], )
 # ARG_OPTIONAL_BOOLEAN([curses], , [Default display is -nographic. switch to -curses instead with this option.\n Use Esc+1, Esc+2, etc. to switch between the different screens.\n 'q' in the monitor screen to quit], )
-# ARG_OPTIONAL_BOOLEAN([git-qemu], [g], [Use a qemu tree at '~/git/qemu/' for qemu binaries.\n This overrides any qemu=<foo> setting from the env.\n This is required and forced for any cxl related options], )
+# ARG_OPTIONAL_SINGLE([git-qemu], , [Use specified qemu tree for qemu binaries.\n This overrides any qemu=<foo> setting from the env.\n This is required and forced for any cxl related options], )
 # ARG_OPTIONAL_BOOLEAN([nfit-test], , [Setup an environment for unit tests\n  - include libnvdimm 'extra' modules\n  - add some memmap reserved memory\n Note: --rebuild=img or higher required when switching either to or away from nfit-test.\n This overrides any supplied 'preset' or topology options and forces preset=med], )
 # ARG_OPTIONAL_BOOLEAN([defconfig], , [Run 'make olddefconfig' before the kernel build], )
 # ARG_OPTIONAL_BOOLEAN([cmdline], , [Print the final qemu command line, but don't start qemu], )

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -227,16 +227,18 @@ process_options_logic()
 		_arg_cxl="on"
 	fi
 	if [[ $_arg_cxl_legacy == "on" ]] || [[ $_arg_cxl == "on" ]]; then
-		_arg_git_qemu="on"
+		if [[ ! $_arg_git_qemu ]]; then
+			_arg_git_qemu=~/git/qemu/
+		fi
 	fi
-	if [[ $_arg_git_qemu == "on" ]]; then
-		qemu=~/git/qemu/x86_64-softmmu/qemu-system-x86_64
-		qemu_img=~/git/qemu/qemu-img
-		qmp=~/git/qemu/scripts/qmp/qmp-shell
+	if [[ $_arg_git_qemu ]]; then
+		qemu=${_arg_git_qemu}/x86_64-softmmu/qemu-system-x86_64
+		qemu_img=${_arg_git_qemu}/qemu-img
+		qmp=${_arg_git_qemu}/scripts/qmp/qmp-shell
 		# upstream changed where binaries go recently
 		if [ ! -f "$qemu_img" ]; then
-			qemu=~/git/qemu/build/qemu-system-x86_64
-			qemu_img=~/git/qemu/build/qemu-img
+			qemu=${_arg_git_qemu}/build/qemu-system-x86_64
+			qemu_img=${_arg_git_qemu}/build/qemu-img
 		fi
 		if [ ! -x "$qemu" ]; then
 			fail "expected to find $qemu"


### PR DESCRIPTION
Remove hardcoded git-qemu path, if the argument is not provided and needed
for cxl options then set ~/git/qemu/ as the default

Signed-off-by: Adam Manzanares <a.manzanares@samsung.com>