### PR TITLE
run_qemu: Don't use glob in if statement

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -649,7 +649,7 @@ make_rootfs()
 	[ -f "$rootfs_script" ] && source "$rootfs_script" mkosi.extra/
 
 	cp -Lr ~/.bash* mkosi.extra/root/
-	if [ -f ~/.vim* ]; then
+	if [ -f ~/.vimrc ]; then
 		rsync "${rsync_opts[@]}" ~/.vim* mkosi.extra/root/
 	fi
 	mkdir -p mkosi.extra/root/bin


### PR DESCRIPTION
The check to install vimrc type files used a glob which fails if one has
more than one .vim* type file.

Use .vimrc to trigger copying a vim environment.

Signed-off-by: Ira Weiny <ira.weiny@intel.com>