### PR TITLE
run_qemu: Add option to skip ndctl build

### DIFF
--- a/parser_generator.m4
+++ b/parser_generator.m4
@@ -28,6 +28,7 @@ exit 11  #)Created by argbash-init v2.9.0
 # ARG_OPTIONAL_BOOLEAN([cxl-test], , [Setup an environment for CXL unit tests\n  - include CXL 'extra' modules to mock a CXL hierarchy using the kernel's 'cxl_test' facility], )
 # ARG_OPTIONAL_BOOLEAN([cxl-test-run], , [CXL unit test mode. Implies the following:\n git-qemu\n cxl\n cxl-debug\n cxl-test\n autorun=rq_cxl_tests.sh\n log=/tmp/rq_<instance>.log\n post-script=rq_cxl_results.sh\n timeout=5\n Any of the above can be overridden from the defaults by manually supplying that option\n], )
 # ARG_OPTIONAL_BOOLEAN([debug], [v], [Debug script problems (enables set -x)], )
+# ARG_OPTIONAL_BOOLEAN([ndctl-build], , [Enable ndctl build in root image], [on])
 # ARG_OPTIONAL_INCREMENTAL([quiet], [q], [quieten some output, can be repeated multiple times to quieten even more], )
 # ARG_OPTIONAL_BOOLEAN([gdb], , [Wait for gdb to connect for kernel debug], )
 # ARG_OPTIONAL_BOOLEAN([gdb-qemu], , [Start qemu with gdb], )

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -579,9 +579,11 @@ __update_existing_rootfs()
 		sudo rm -f "$inst_prefix"/usr/lib/modules/"$kver"/extra/cxl_*.ko
 	fi
 
-	ndctl_dst="$inst_prefix/root/ndctl"
-	if [ -d "$ndctl" ] && [ -d "$ndctl_dst" ]; then
-		rsync "${rsync_opts[@]}" "$ndctl/" "$ndctl_dst"
+	if [[ $_arg_ndctl_build == "on" ]]; then
+		ndctl_dst="$inst_prefix/root/ndctl"
+		if [ -d "$ndctl" ] && [ -d "$ndctl_dst" ]; then
+			rsync "${rsync_opts[@]}" "$ndctl/" "$ndctl_dst"
+		fi
 	fi
 
 	sudo -E bash -c "$(declare -f setup_depmod); _arg_nfit_test=$_arg_nfit_test; _arg_cxl_test=$_arg_cxl_test; kver=$kver; setup_depmod $inst_prefix"
@@ -674,8 +676,10 @@ make_rootfs()
 	if [ -d ~/git/extra-scripts ]; then
 		rsync "${rsync_opts[@]}" ~/git/extra-scripts/bin/* mkosi.extra/root/bin/
 	fi
-	if [ -d "$ndctl" ]; then
-		rsync "${rsync_opts[@]}" "$ndctl/" mkosi.extra/root/ndctl
+	if [[ $_arg_ndctl_build == "on" ]]; then
+		if [ -d "$ndctl" ]; then
+			rsync "${rsync_opts[@]}" "$ndctl/" mkosi.extra/root/ndctl
+		fi
 	fi
 	if [ -f /etc/localtime ]; then
 		mkdir -p mkosi.extra/etc/
@@ -700,7 +704,9 @@ make_rootfs()
 	setup_depmod "mkosi.extra"
 	setup_autorun "mkosi.extra"
 
-	prepare_ndctl_build
+	if [[ $_arg_ndctl_build == "on" ]]; then
+		prepare_ndctl_build
+	fi
 	mkosi_ver="$("$mkosi_bin" --version | awk '/mkosi/{ print $2 }')"
 	if (( mkosi_ver >= 9 )); then
 		mkosi_opts+=("--autologin")


### PR DESCRIPTION
When testing non-ndctl code while at the same time having ndctl changes
in progress it is beneficial to temporarily skip the ndctl build/install
in the root image.  This is because failures of the ndctl build will
stop running qemu despite not needing ndctl for the current test
required.

Add an option to skip ndctl build/install within the root image.  To
maintain current compatibility enable it by default.

Signed-off-by: Ira Weiny <ira.weiny@intel.com>