### PR TITLE
mkosi.ubuntu: Add some missing packages

### DIFF
--- a/mkosi.ubuntu.default.tmpl
+++ b/mkosi.ubuntu.default.tmpl
@@ -14,6 +14,12 @@ Output=@ROOT_FS@
 
 [Packages]
 Packages=
+  ndctl
+  openssh-client
+  lsof
+  strace
+  ltrace
+  fio
   build-essential
   vim
   autoconf


### PR DESCRIPTION
The following packages were added:

* fio: flexible I/O tester
* lsof: Utility to list open files
* ltrace: Track runtime library calls
* ndctl: the packages tht provides the cxl CLI in Ubuntu
* openssh-client: SSH client, was missing
* strace: System call tracer

Signed-off-by: Jonathan Gonzalez V <jonathan.abdiel@gmail.com>