### PR TITLE
run_qemu: Add kernel selftests build option

### DIFF
--- a/parser_generator.m4
+++ b/parser_generator.m4
@@ -29,6 +29,7 @@ exit 11  #)Created by argbash-init v2.9.0
 # ARG_OPTIONAL_BOOLEAN([cxl-test-run], , [CXL unit test mode. Implies the following:\n git-qemu\n cxl\n cxl-debug\n cxl-test\n autorun=rq_cxl_tests.sh\n log=/tmp/rq_<instance>.log\n post-script=rq_cxl_results.sh\n timeout=5\n Any of the above can be overridden from the defaults by manually supplying that option\n], )
 # ARG_OPTIONAL_BOOLEAN([debug], [v], [Debug script problems (enables set -x)], )
 # ARG_OPTIONAL_BOOLEAN([ndctl-build], , [Enable ndctl build in root image], [on])
+# ARG_OPTIONAL_BOOLEAN([kern-selftests], , [Enable kernel selftest build in root image (Warning: This option can take a long time and requires many support packages on the host; including some 32 bit)], [off])
 # ARG_OPTIONAL_INCREMENTAL([quiet], [q], [quieten some output, can be repeated multiple times to quieten even more], )
 # ARG_OPTIONAL_BOOLEAN([gdb], , [Wait for gdb to connect for kernel debug], )
 # ARG_OPTIONAL_BOOLEAN([gdb-qemu], , [Start qemu with gdb], )


### PR DESCRIPTION
Testing of core kernel functionality is often implemented in the kernel selftests located in source sub-tree tools/testing/selftests.

Running these tests are often required to properly ensure kernel changes have not created a regression.

Add --kern-selftests option to include a build of the kernel selftests in the root home dir of the qemu build.  Due to the lengthy build time the default for this option is 'off'.

Signed-off-by: Ira Weiny <ira.weiny@intel.com>