### PR TITLE
mkosi.arch: add requirement packages for ndctl

### DIFF
--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -14,15 +14,22 @@ Output=@ROOT_FS@
 [Packages]
 Packages=
   acpica
+  asciidoctor
   bash-completion
+  cmake
   dhclient
   fio
+  gcc
   gdb
   git
+  iniparser
   iproute2
   jq
   kmod
+  libtraceevent
+  libtracefs
   lsof
+  make
   man-db
   neovim
   net-tools


### PR DESCRIPTION
If ~/git/ndctl exists, it will build the ndctl by default.  But in Archlinux, it will get error because the required packages are missing. So, add them here.