### PR TITLE
run_qemu: Add dax debug switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ The script enables generating a sane QEMU commandline for instantiating a basic 
 - --cxl-hb: Turn q35 into a CXL capable Host bridge. Don't use this option unless you're working on support for this.
 - --cxl-test-run: Attempt to do a sanity test of the kernel and QEMU configuration.
 
+## DAX Usage
+
+- --dax-debug: Add any and all flags for extra debug of dax modules (kernel)
+
 ### Kernel config
 - Make sure to Turn on CXL related options in the kernel's .config:
 ```

--- a/parser_generator.m4
+++ b/parser_generator.m4
@@ -28,6 +28,7 @@ exit 11  #)Created by argbash-init v2.9.0
 # ARG_OPTIONAL_BOOLEAN([cxl-debug], , [Enable 'dyndbg' for CXL modules.], )
 # ARG_OPTIONAL_BOOLEAN([cxl-test], , [Setup an environment for CXL unit tests\n  - include CXL 'extra' modules to mock a CXL hierarchy using the kernel's 'cxl_test' facility], )
 # ARG_OPTIONAL_BOOLEAN([cxl-test-run], , [CXL unit test mode. Implies the following:\n git-qemu\n cxl\n cxl-debug\n cxl-test\n autorun=rq_cxl_tests.sh\n log=/tmp/rq_<instance>.log\n post-script=rq_cxl_results.sh\n timeout=5\n Any of the above can be overridden from the defaults by manually supplying that option\n], )
+# ARG_OPTIONAL_BOOLEAN([dax-debug], , [Enable 'dyndbg' for DAX modules.], )
 # ARG_OPTIONAL_BOOLEAN([debug], [v], [Debug script problems (enables set -x)], )
 # ARG_OPTIONAL_BOOLEAN([ndctl-build], , [Enable ndctl build in root image], [on])
 # ARG_OPTIONAL_BOOLEAN([kern-selftests], , [Enable kernel selftest build in root image (Warning: This option can take a long time and requires many support packages on the host; including some 32 bit)], [off])

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -528,6 +528,13 @@ build_kernel_cmdline()
 			"cxl_mock_mem.dyndbg=+fplm"
 		)
 	fi
+	if [[ $_arg_dax_debug == "on" ]]; then
+		kcmd+=(
+			"dax.dyndbg=+fplm"
+			"dax_cxl.dyndbg=+fplm"
+			"device_dax.dyndbg=+fplm"
+		)
+	fi
 	if [[ $_arg_nfit_debug == "on" ]]; then
 		kcmd+=( 
 			"libnvdimm.dyndbg=+fplm"


### PR DESCRIPTION
Some tests benefit from getting dax module debug messages.  Specifically Dynamic Capacity Devices require the use of dax devices to fully test the management of extents.

Add an option --dax-debug to add the debug messages for some dax modules including dax_cxl.