### PR TITLE
run_qemu: extend the size of ESP partition

### DIFF
--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -4,6 +4,7 @@ Release=@OS_RELEASE@
 
 [Partitions]
 RootSize=@ROOT_SIZE@
+ESPSize=@ESP_SIZE@
 
 [Output]
 Format=raw_gpt

--- a/mkosi.fedora.default.tmpl
+++ b/mkosi.fedora.default.tmpl
@@ -4,6 +4,7 @@ Release=@OS_RELEASE@
 
 [Partitions]
 RootSize=@ROOT_SIZE@
+ESPSize=@ESP_SIZE@
 
 [Output]
 Format=raw_gpt

--- a/mkosi.ubuntu.default.tmpl
+++ b/mkosi.ubuntu.default.tmpl
@@ -4,7 +4,7 @@ Release=@OS_RELEASE@
 
 [Partitions]
 RootSize=@ROOT_SIZE@
-ESPSize=512M
+ESPSize=@ESP_SIZE@
 
 [Output]
 Format=raw_gpt

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -6,6 +6,7 @@
 : "${builddir:=./qbuild}"
 rootpw="root"
 rootfssize="10G"
+espsize="512M"
 nvme_size="1G"
 efi_mem_size="2"   #in GiB
 legacy_pmem_size="2"   #in GiB
@@ -855,6 +856,7 @@ make_rootfs()
 	mkdir -p mkosi.builddir
 	sed -e "s:@OS_DISTRO@:${distro}:" \
 		-e "s:@OS_RELEASE@:${rev}:" \
+		-e "s:@ESP_SIZE@:${espsize}:" \
 		-e "s:@ROOT_SIZE@:${rootfssize}:" \
 		-e "s:@ROOT_FS@:${_arg_rootfs}:" \
 		-e "s:@ROOT_PASS@:${rootpw}:" \


### PR DESCRIPTION
In some cases, such as fedora37, 'insufficient disk space error' was occurred during building the root.img.

The root cause is that the ESPSize(256M by default) is not set in the mkosi.fedora.default.tmpl.  If the ESP partition is larger than 256M, this error(shown as below) occurrs.

So, extend the ESPSize to 512M for all distroes to avoid the error.

Error log:
$ run_qemu.sh --cxl
...
‣  Refreshed partition table.
‣  Attaching /home/linux-6.7/qbuild/.mkosi-ru0kjlr1 as loopback… ‣  Attached /dev/loop0
‣  Refreshing file system /dev/loop0p2…
tune2fs 1.46.5 (30-Dec-2021)
‣  Mounting image…
‣  Copying in extra file trees…
‣  Generating initramfs images…
/usr/bin/dracut: line 1056: /sys/module/firmware_class/parameters/path: No such file or directory dracut: No '/dev/log' or 'logger' included for syslog logging /usr/bin/dracut: line 1056: /sys/module/firmware_class/parameters/path: No such file or directory dracut: No '/dev/log' or 'logger' included for syslog logging cp: error writing '/efi/fdc1f6a6cc9d49e9a7f1ead5f03d4fcb/6.7.0/initrd': No space left on device dracut: Creation of /efi/fdc1f6a6cc9d49e9a7f1ead5f03d4fcb/6.7.0/initrd failed ‣ Error: Workspace command kernel-install add 6.7.0 /lib/modules/6.7.0/vmlinuz returned non-zero exit code 1. ‣  (Unmounting image)
‣  (Detaching /dev/loop0)