### PR TITLE
run_qemu.sh: Prompt invalid parameter error

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -90,6 +90,12 @@ fi
 # shellcheck source=run_qemu_parser.sh
 . "${script_dir}/run_qemu_parser.sh" || fail "Couldn't find $parser_lib"
 
+if [ ${_arg_working_dir:0:1} == "-" ]; then
+	printf "Invalid option '%s'\n" "$_arg_working_dir"
+	printf "Try 'run_qemu.sh --help' for more information.\n"
+	exit 1
+fi
+
 cxl_test_script="$script_dir/scripts/rq_cxl_tests.sh"
 cxl_results_script="$script_dir/scripts/rq_cxl_results.sh"
 nfit_test_script="$script_dir/scripts/rq_nfit_tests.sh"


### PR DESCRIPTION
Argbash cannot report if an invalid parameter is set, it will think this parameter as working_dir, and then show meaningless message:

  $ run_qemu.sh --clx
  /usr/local/bin/run_qemu.sh: line 105: pushd: --clx: invalid number
  pushd: usage: pushd [-n] [+N | -N | dir]
  couldn't cd to --clx

Add check and print useful message:

  $ run_qemu.sh --clx
  Invalid option '--clx'
  Try 'run_qemu.sh --help' for more information.