### PR TITLE
run_qemu: update the arguments of --rebuild in completion script

### DIFF
--- a/run_qemu
+++ b/run_qemu
@@ -25,7 +25,7 @@ _run_qemu()
 			;;
 		--rebuild=*)
 			cur=${cur#*=}
-			COMPREPLY=($(compgen -W 'wipe img kmod kernel none' -- ${cur}))
+			COMPREPLY=($(compgen -W 'wipe imgcache img kmod none' -- ${cur}))
 			return
 			;;
 		--mirror=*)


### PR DESCRIPTION
The 'kernel' argument is deprecated, and 'imgcache' is newly added for the --rebuild, but we can still find the 'kernel' through bash completion and can not find 'imgcache':

$ run_qemu.sh --rebuild=
img     kernel  kmod    none    wipe