### PR TITLE
run_qemu: Label size must be 4K

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -54,7 +54,7 @@ cross_pmem_dist=28
 cxl_addr="0x4c00000000"
 cxl_backend_size="512M"
 cxl_t3_size="256M"
-cxl_label_size="1K"
+cxl_label_size="4K"
 
 num_build_cpus="$(($(getconf _NPROCESSORS_ONLN) + 1))"
 rsync_opts=("--delete" "--exclude=.git/" "--exclude=build/" "-L" "-r")


### PR DESCRIPTION
The latest upstream qemu master requires memory backend files to be a multiple of 4k.

Change the label size to be 4k to match this requirement.