### PR TITLE
run_qemu: Increase label size to a more usable value

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -54,7 +54,7 @@ cross_pmem_dist=28
 cxl_addr="0x4c00000000"
 cxl_backend_size="512M"
 cxl_t3_size="256M"
-cxl_label_size="4K"
+cxl_label_size="128K"
 
 num_build_cpus="$(($(getconf _NPROCESSORS_ONLN) + 1))"
 rsync_opts=("--delete" "--exclude=.git/" "--exclude=build/" "-L" "-r")


### PR DESCRIPTION
The label size of 4k may not hold a modern Optane label.  While the 4k value fixed the issue with qemu a more reasonable value is 128k which can safely hold many labels.

Increase the label space to 128k