### PR TITLE
run_qemu.sh: use host CPU capability to avoid guest boot failed issue

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1314,6 +1314,8 @@ prepare_qcmd()
 
 	qcmd+=("-device" "e1000,netdev=net0,mac=$mac_addr")
 	qcmd+=("-netdev" "user,id=net0,hostfwd=tcp::$hostport-:22")
+	# Use host CPU capability
+	qcmd+=("-cpu" "host")
 
 	if [[ $_arg_cxl == "on" ]]; then
 		setup_cxl


### PR DESCRIPTION
Use host CPU capability to avoid guest boot failed issue: Fatal glibc error: CPU does not support x86-64-v2