### PR TITLE
run_qemu.sh: add more cmdline for testing and debug

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -587,6 +587,8 @@ build_kernel_cmdline()
 		"root=$root"
 		"ignore_loglevel"
 		"rw"
+		"initcall_debug"
+		"log_buf_len=20M"
 		"memory_hotplug.memmap_on_memory=force"
 	)
 	if [[ $_arg_gdb == "on" ]]; then


### PR DESCRIPTION
Add more cmdline for testing and debug:
1. add initcall_debug to debug some module init hang issues easily
2. add log_buf_len=20M for dmesg log size, when test cxl qemu ndctl cases, could not collect the full dmesg log due to default dmesg size is too small, now set dmesg size to 20M as default, it's enough for dmesg debug.