### PR TITLE
run_qemu.sh: de-hardcode .ssh/id_rsa.pub

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -916,7 +916,12 @@ make_rootfs()
 
 	# misc rootfs setup
 	mkdir -p mkosi.extra/root/.ssh
-	cp -L ~/.ssh/id_rsa.pub mkosi.extra/root/.ssh/authorized_keys
+	local pubk
+	for pubk in ~/.ssh/*.pub; do
+		if test -e "${pubk%.pub}"; then
+			cat "${pubk}"
+		fi
+	done > mkosi.extra/root/.ssh/authorized_keys
 	chmod -R go-rwx mkosi.extra/root
 
 	rootfs_script="${script_dir}/${distro}_rootfs.sh"


### PR DESCRIPTION
Stop failing and aborting the entire build when .ssh/id_rsa.pub is not found; RSA is outdated and insecure. Instead, install all .pub keys for which we have the private part. As a bonus, this also keeps building on systems that have no private keys (e.g. when using ssh agent forwarding).