### PR TITLE
Minor fixes to run mkosi from git

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -977,8 +977,15 @@ make_rootfs()
 		prepare_ndctl_build
 	fi
 	mkosi_ver="$("$mkosi_bin" --version | awk '/mkosi/{ print $2 }')"
+	# drop the "~devel" suffix present in __version__ when running from
+	# pre-v25 versions
+	mkosi_ver="${mkosi_ver%%~*}"
 	# only look at the major version
 	mkosi_ver="${mkosi_ver%%.*}"
+	# Make sure we got a number
+	test "$mkosi_ver" -eq "$mkosi_ver" ||
+		fail 'mkosi version %s is not a number' "$mkosi_ver"
+
 	if (( mkosi_ver >= 9 )) && [[ $_arg_gcp == "off" ]]; then
 		mkosi_opts+=("--autologin")
 	fi

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -982,7 +982,8 @@ make_rootfs()
 	fi
 	mkosi_opts+=("build")
 	if (( _arg_quiet < 3 )); then
-		echo "running: $mkosi_bin ${mkosi_opts[*]}"
+		echo "in directory: $(pwd)"
+		echo "running: sudo -E $mkosi_bin ${mkosi_opts[*]}"
 	fi
 	if (( _arg_quiet >= 1 )); then
 		sudo -E "$mkosi_bin" "${mkosi_opts[@]}" > /dev/null 2>&1

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -120,6 +120,20 @@ distro_vars="${script_dir}/${distro}_vars.sh"
 
 pushd "$_arg_working_dir" > /dev/null || fail "couldn't cd to $_arg_working_dir"
 
+set_valid_mkosi_ver()
+{
+	mkosi_ver="$("$mkosi_bin" --version | awk '/mkosi/{ print $2 }')"
+	# drop the "~devel" suffix present in __version__ when running from
+	# pre-v25 versions
+	mkosi_ver="${mkosi_ver%%~*}"
+	# only look at the major version
+	mkosi_ver="${mkosi_ver%%.*}"
+	# Make sure we got a number
+	test "$mkosi_ver" -eq "$mkosi_ver" ||
+		fail 'mkosi version %s is not a number' "$mkosi_ver"
+}
+set_valid_mkosi_ver
+
 kill_guest()
 {
 	# sometimes this can be inadvertently re-entrant
@@ -976,15 +990,6 @@ make_rootfs()
 	if [[ $_arg_ndctl_build == "on" ]]; then
 		prepare_ndctl_build
 	fi
-	mkosi_ver="$("$mkosi_bin" --version | awk '/mkosi/{ print $2 }')"
-	# drop the "~devel" suffix present in __version__ when running from
-	# pre-v25 versions
-	mkosi_ver="${mkosi_ver%%~*}"
-	# only look at the major version
-	mkosi_ver="${mkosi_ver%%.*}"
-	# Make sure we got a number
-	test "$mkosi_ver" -eq "$mkosi_ver" ||
-		fail 'mkosi version %s is not a number' "$mkosi_ver"
 
 	if (( mkosi_ver >= 9 )) && [[ $_arg_gcp == "off" ]]; then
 		mkosi_opts+=("--autologin")

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -980,6 +980,14 @@ make_rootfs()
 	if (( mkosi_ver >= 9 )) && [[ $_arg_gcp == "off" ]]; then
 		mkosi_opts+=("--autologin")
 	fi
+
+	if [[ $_arg_debug == "on" ]]; then
+	    # In case of yet another mkosi incompatibility or other issue,
+	    # enable this line. WARNING: --debug options have "stability" issues
+	    # too! Check the man page of your specific mkosi version
+	    : # mkosi_opts+=('--debug-workspace' '--debug-shell' '--debug')
+	fi
+
 	mkosi_opts+=("build")
 	if (( _arg_quiet < 3 )); then
 		echo "in directory: $(pwd)"

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -81,7 +81,9 @@ fi
 
 fail()
 {
-	printf "%s\n" "$*"
+	# shellcheck disable=SC2059
+	printf "$@"
+	printf '\n'
 	exit 1
 }
 


### PR DESCRIPTION
Warning: this is VERY FAR from enough to make run_qemu.sh compatible with recent mkosi versions. But it helps.