### PR TITLE
mkosi.conf fixes to prepare for v15. Bump required version to v11

### DIFF
--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -7,7 +7,7 @@ RootSize=@ROOT_SIZE@
 ESPSize=@ESP_SIZE@
 
 [Output]
-Format=raw_gpt
+Format=gpt_ext4
 Bootable=yes
 WithUnifiedKernelImages=no
 Output=@ROOT_FS@

--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -1,17 +1,3 @@
-[Distribution]
-Distribution=@OS_DISTRO@
-Release=@OS_RELEASE@
-
-[Partitions]
-RootSize=@ROOT_SIZE@
-ESPSize=@ESP_SIZE@
-
-[Output]
-Format=gpt_ext4
-Bootable=yes
-WithUnifiedKernelImages=no
-Output=@ROOT_FS@
-
 [Content]
 Packages=
   acpica

--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -12,7 +12,7 @@ Bootable=yes
 WithUnifiedKernelImages=no
 Output=@ROOT_FS@
 
-[Packages]
+[Content]
 Packages=
   acpica
   asciidoctor

--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -46,6 +46,3 @@ Packages=
   meson
   util-linux
   hwloc
-
-[Validation]
-Password=@ROOT_PASS@

--- a/mkosi.debian.default.tmpl
+++ b/mkosi.debian.default.tmpl
@@ -1,17 +1,3 @@
-[Distribution]
-Distribution=@OS_DISTRO@
-Release=@OS_RELEASE@
-
-[Partitions]
-RootSize=@ROOT_SIZE@
-ESPSize=@ESP_SIZE@
-
-[Output]
-Format=gpt_ext4
-Bootable=yes
-WithUnifiedKernelImages=no
-Output=@ROOT_FS@
-
 [Content]
 Packages=
   asciidoctor

--- a/mkosi.debian.default.tmpl
+++ b/mkosi.debian.default.tmpl
@@ -46,4 +46,3 @@ Packages=
   strace
   uuid-dev
   vim
-Password=@ROOT_PASS@

--- a/mkosi.fedora.default.tmpl
+++ b/mkosi.fedora.default.tmpl
@@ -7,7 +7,7 @@ RootSize=@ROOT_SIZE@
 ESPSize=@ESP_SIZE@
 
 [Output]
-Format=raw_gpt
+Format=gpt_ext4
 Bootable=yes
 WithUnifiedKernelImages=no
 Output=@ROOT_FS@

--- a/mkosi.fedora.default.tmpl
+++ b/mkosi.fedora.default.tmpl
@@ -94,6 +94,3 @@ Packages=
   perf
   hwloc
   systemd-boot-unsigned
-
-[Validation]
-Password=@ROOT_PASS@

--- a/mkosi.fedora.default.tmpl
+++ b/mkosi.fedora.default.tmpl
@@ -12,7 +12,7 @@ Bootable=yes
 WithUnifiedKernelImages=no
 Output=@ROOT_FS@
 
-[Packages]
+[Content]
 Packages=
   openssh-clients
   openssh-server

--- a/mkosi.fedora.default.tmpl
+++ b/mkosi.fedora.default.tmpl
@@ -1,17 +1,3 @@
-[Distribution]
-Distribution=@OS_DISTRO@
-Release=@OS_RELEASE@
-
-[Partitions]
-RootSize=@ROOT_SIZE@
-ESPSize=@ESP_SIZE@
-
-[Output]
-Format=gpt_ext4
-Bootable=yes
-WithUnifiedKernelImages=no
-Output=@ROOT_FS@
-
 [Content]
 Packages=
   openssh-clients

--- a/mkosi.generic.conf.tmpl
+++ b/mkosi.generic.conf.tmpl
@@ -1,0 +1,13 @@
+[Distribution]
+Distribution=@OS_DISTRO@
+Release=@OS_RELEASE@
+
+[Partitions]
+RootSize=@ROOT_SIZE@
+ESPSize=@ESP_SIZE@
+
+[Output]
+Format=gpt_ext4
+Bootable=yes
+WithUnifiedKernelImages=no
+Output=@ROOT_FS@

--- a/mkosi.ubuntu.default.tmpl
+++ b/mkosi.ubuntu.default.tmpl
@@ -7,7 +7,7 @@ RootSize=@ROOT_SIZE@
 ESPSize=@ESP_SIZE@
 
 [Output]
-Format=raw_gpt
+Format=gpt_ext4
 Bootable=yes
 WithUnifiedKernelImages=no
 Output=@ROOT_FS@

--- a/mkosi.ubuntu.default.tmpl
+++ b/mkosi.ubuntu.default.tmpl
@@ -12,7 +12,7 @@ Bootable=yes
 WithUnifiedKernelImages=no
 Output=@ROOT_FS@
 
-[Packages]
+[Content]
 Packages=
   ndctl
   openssh-client

--- a/mkosi.ubuntu.default.tmpl
+++ b/mkosi.ubuntu.default.tmpl
@@ -44,6 +44,3 @@ Packages=
   libtraceevent-dev
   libsystemd-dev
   meson
-
-[Validation]
-Password=@ROOT_PASS@

--- a/mkosi.ubuntu.default.tmpl
+++ b/mkosi.ubuntu.default.tmpl
@@ -1,17 +1,3 @@
-[Distribution]
-Distribution=@OS_DISTRO@
-Release=@OS_RELEASE@
-
-[Partitions]
-RootSize=@ROOT_SIZE@
-ESPSize=@ESP_SIZE@
-
-[Output]
-Format=gpt_ext4
-Bootable=yes
-WithUnifiedKernelImages=no
-Output=@ROOT_FS@
-
 [Content]
 Packages=
   ndctl

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -931,6 +931,7 @@ make_rootfs()
 		-e "s:@ESP_SIZE@:${espsize}:" \
 		-e "s:@ROOT_SIZE@:${rootfssize}:" \
 		-e "s:@ROOT_FS@:${_arg_rootfs}:" \
+		"${script_dir}"/mkosi.generic.conf.tmpl \
 		"${script_dir}"/mkosi.${distro}.default.tmpl > mkosi.conf
 
 	# This depends on the [Content] section being last

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -931,8 +931,10 @@ make_rootfs()
 		-e "s:@ESP_SIZE@:${espsize}:" \
 		-e "s:@ROOT_SIZE@:${rootfssize}:" \
 		-e "s:@ROOT_FS@:${_arg_rootfs}:" \
-		-e "s:@ROOT_PASS@:${rootpw}:" \
 		"${script_dir}"/mkosi.${distro}.default.tmpl > mkosi.conf
+
+	# This depends on the [Content] section being last
+	printf '\nPassword=%s\n' "${rootpw}" >> mkosi.conf
 
 	# Backwards compatibility with mkosi v14 and below
 	rm -f mkosi.default

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -134,6 +134,10 @@ set_valid_mkosi_ver()
 }
 set_valid_mkosi_ver
 
+# [Packages] was renamed to [Content] in v11, see mkosi/NEWS.md
+test "$mkosi_ver" -ge 11 ||
+	fail 'mkosi version 11 or above is required, found %s' "$mkosi_ver"
+
 kill_guest()
 {
 	# sometimes this can be inadvertently re-entrant
@@ -995,7 +999,7 @@ make_rootfs()
 		prepare_ndctl_build
 	fi
 
-	if (( mkosi_ver >= 9 )) && [[ $_arg_gcp == "off" ]]; then
+	if [[ $_arg_gcp == "off" ]]; then
 		mkosi_opts+=("--autologin")
 	fi
 

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -928,7 +928,11 @@ make_rootfs()
 		-e "s:@ROOT_SIZE@:${rootfssize}:" \
 		-e "s:@ROOT_FS@:${_arg_rootfs}:" \
 		-e "s:@ROOT_PASS@:${rootpw}:" \
-		"${script_dir}"/mkosi.${distro}.default.tmpl > mkosi.default
+		"${script_dir}"/mkosi.${distro}.default.tmpl > mkosi.conf
+
+	# Backwards compatibility with mkosi v14 and below
+	rm -f mkosi.default
+	ln mkosi.conf mkosi.default
 
 	# misc rootfs setup
 	mkdir -p mkosi.extra/root/.ssh


### PR DESCRIPTION
Again this is still a bit far from achieving compatibility with mkosi v15 but this time it's a major step forward - and this should have zero effect on v14 users for now.

See commit messages.