### PR TITLE
Revert "run_qemu: switch mkosi to not build unified kernel images"

### DIFF
--- a/mkosi.generic.conf.tmpl
+++ b/mkosi.generic.conf.tmpl
@@ -9,5 +9,4 @@ ESPSize=@ESP_SIZE@
 [Output]
 Format=gpt_ext4
 Bootable=yes
-WithUnifiedKernelImages=no
 Output=@ROOT_FS@


### PR DESCRIPTION
mkosi.generic.conf.tmpl: re-enable UnifiedKernelImages

This reverts commit 92ac46548ca7d933383ec8617311052bf6a3d12a

The build of the Unified Kernel Image was disabled 18 months ago but no one can remember now what problem this solved at the time. It should be possible to just ignore this byproduct.

For some unknown reason, reverting this fixes the build on Ubuntu 22.04 with mkosi version 12:
```
running: sudo -E mkosi -i -f --autologin build
Error: Sorry, --without-unified-kernel-images is not supported in
UEFI mode on this distro.
```

Reverting this also helps the (upcoming) compatibility with mkosi v15+ because this option has been entirely removed from mkosi v15+! Quoting any recent mkosi/NEWS.md:

```
    v15

    We also remove the WithoutUnifiedKernelImages= switch as building
    unified kernel images is trivial and fast these days.
```