### PR TITLE
mkosi.arch.default.tmpl: add systemd

### DIFF
--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -32,3 +32,4 @@ Packages=
   meson
   util-linux
   hwloc
+  systemd


### PR DESCRIPTION
Fixes the following error when trying to build with mkosi v15:

>  Setting up autologin…
>  A bootable image was requested but systemd-boot was not found
>     at usr/lib/systemd/boot/efi

I don't know how mkosi v14 does not need this but asking explicitly for systemd does not hurt mkosi v14.