### PR TITLE
run_qemu.sh: move get_ovmf_binaries() later, to start_qemu()

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1332,8 +1332,6 @@ prepare_qcmd()
 
 	pushd "$builddir" > /dev/null || exit 1
 
-	get_ovmf_binaries
-
 	if [[ ! $kver ]] && [[ $_arg_kver ]]; then
 		kver="$_arg_kver"
 	fi
@@ -1495,6 +1493,8 @@ prepare_qcmd()
 start_qemu()
 {
 	pushd "$builddir" > /dev/null || exit 1
+
+	get_ovmf_binaries
 
 	if [[ $_arg_log ]]; then
 		if (( _arg_quiet < 3 )); then


### PR DESCRIPTION
prepare_qcmd() does not need OVMF binaries, they're needed only later when actually trying to start QEMU. This makes it possible to build successfully with `run_qemu.sh --no-run` even when OVMF binaries are not found (each distro tends to place them in a different place).