### PR TITLE
run_qemu.sh: print warning that --ndctl-build never worked incrementally

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -863,9 +863,9 @@ __update_existing_rootfs()
 	fi
 
 	if [[ $_arg_ndctl_build == "on" ]]; then
-		ndctl_dst="$inst_prefix/root/ndctl"
-		if [ -d "$ndctl" ] && [ -d "$ndctl_dst" ]; then
-			rsync "${rsync_opts[@]}" "$ndctl/" "$ndctl_dst"
+		if [ -n "$ndctl" ] && [ -f "$ndctl/meson.build" ]; then
+			>&2 printf '\n%s\n\n' \
+'WARNING: --ndctl-build ignored when updating existing image! Outdated ndctl in the image. Try adding "-r img"'
 		fi
 	fi
 


### PR DESCRIPTION
The update_existing_rootfs() function is part of a hidden shortcut that does not run mkosi. It had a tentative feature that wanted to invoke rsync to update `ndctl` sources in the existing image. That ndctl shortcut never actually did anything!

- Replace that broken rsync with a warning in case anyone thought this was working.
- Do not print the warning when `$ndctl` is undefined or ill-defined because --ndctl-build is ON by default and `$ndctl` is in practice used as the actual ndctl "switch".

1. This feature apparently _never worked_ and always left outdated sources _silently_. That's because the mount point requires root access, which made the `test [ -d qbuild/mnt/root/ndctl ]` always return false - without any message!

2. Even if that `rsync` had worked (with the appropriate "sudose"), sources would still have not been _compiled_; there was no attempt to compile. This would have left binaries out of date with sources inside the image, been inconsistent with building from scratch and would have been very confusing and dangerous too.

Compiling and installing requires the container/chroot which is currently available "for free" when building from scratch. But it is not straight-forward in the shortcut case.

Speaking of containers, support for mkosi v15 and above in the other, main ndctl deployment code path (from scratch or with `-r img`) requires container-related changes in mkosi.postinst. See v15 commit https://github.com/systemd/mkosi/commit/9b626c647037bc8a). These unrelated and upcoming changes will hopefully make it easier to finally implement this feature.