### PR TITLE
.github: enable ndctl build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
             img_distro: ubuntu
             img_rel: noble
         arch: [x86_64]
-        run_opts: [--cxl]
+        run_opts: [--cxl --ndctl-build]
 
     steps:
       - uses: actions/checkout@v4
@@ -79,6 +79,12 @@ jobs:
           sudo apt install -y autoconf
           sudo make -C argbash-${AB_VER}/resources install PREFIX=/usr/local/
 
+      - name: download ndctl
+        uses: actions/checkout@v4
+        with:
+          repository: pmem/ndctl
+          path: ndctl
+
       - name: download kernel
         uses: actions/checkout@v4
         with:
@@ -105,6 +111,7 @@ jobs:
           mkosi --version
           cd kernel
           distro=${{ matrix.cfg.img_distro }} rev=${{ matrix.cfg.img_rel }} \
+                 ndctl='${{ github.workspace }}'/ndctl \
                  ../run_qemu/run_qemu.sh -v --no-run ${{ matrix.run_opts }}
 
       # TODO: drop --no-run thanks to "nested KVM" or something?

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -937,9 +937,6 @@ prepare_ndctl_build()
 	cat <<- EOF > mkosi.postinst
 		#!/bin/bash -ex
 
-		if [[ ! -d /root/ndctl ]]; then
-			exit 0
-		fi
 		pushd /root/ndctl
 		rm -rf build
 		meson setup build
@@ -1072,8 +1069,8 @@ make_rootfs()
 	if [[ $_arg_ndctl_build == "on" ]]; then
 		if [ -n "$ndctl" ]; then
 			rsync "${rsync_opts[@]}" "$ndctl/" mkosi.extra/root/ndctl
+			prepare_ndctl_build # create mkosi.postinst which compiles
 		fi
-		prepare_ndctl_build
 	fi
 	if [ -f /etc/localtime ]; then
 		mkdir -p mkosi.extra/etc/

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1063,6 +1063,7 @@ make_rootfs()
 		if [ -d "$ndctl" ]; then
 			rsync "${rsync_opts[@]}" "$ndctl/" mkosi.extra/root/ndctl
 		fi
+		prepare_ndctl_build
 	fi
 	if [ -f /etc/localtime ]; then
 		mkdir -p mkosi.extra/etc/
@@ -1090,10 +1091,6 @@ make_rootfs()
 
 	setup_depmod "mkosi.extra"
 	setup_autorun "mkosi.extra"
-
-	if [[ $_arg_ndctl_build == "on" ]]; then
-		prepare_ndctl_build
-	fi
 
 	if [[ $_arg_gcp == "off" ]]; then
 		mkosi_opts+=("--autologin")

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -407,6 +407,8 @@ process_options_logic()
 	if [[ $_arg_kvm = "off" ]]; then
 		accel="tcg"
 	fi
+
+	check_ndctl_dir
 }
 
 make_install_kernel()
@@ -922,6 +924,14 @@ setup_network()
 	EOF
 }
 
+check_ndctl_dir()
+{
+	if [ -n "$ndctl" ]; then
+		[ -f "$ndctl/meson.build" ] ||
+		    fail 'ndctl="%s" is not a valid source directory\n' "$ndctl"
+	fi
+}
+
 prepare_ndctl_build()
 {
 	cat <<- EOF > mkosi.postinst
@@ -1060,7 +1070,7 @@ make_rootfs()
 		rsync "${rsync_opts[@]}" ~/git/extra-scripts/bin/* mkosi.extra/root/bin/
 	fi
 	if [[ $_arg_ndctl_build == "on" ]]; then
-		if [ -d "$ndctl" ]; then
+		if [ -n "$ndctl" ]; then
 			rsync "${rsync_opts[@]}" "$ndctl/" mkosi.extra/root/ndctl
 		fi
 		prepare_ndctl_build


### PR DESCRIPTION
As --ndctl-build is on by default, the "real" way to enable ndctl is to define $ndctl.

Add --ndctl-build anyway in case the default ever changes.