### PR TITLE
.github: drop "sudo" in "sudo run_qemu.sh"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           mkosi --version
           cd kernel
-          sudo -E distro=${{ matrix.cfg.img_distro }} rev=${{ matrix.cfg.img_rel }} \
+          distro=${{ matrix.cfg.img_distro }} rev=${{ matrix.cfg.img_rel }} \
                  ../run_qemu/run_qemu.sh -v --no-run ${{ matrix.run_opts }}
 
       # TODO: drop --no-run thanks to "nested KVM" or something?


### PR DESCRIPTION
run_qemu.sh already uses sudo a lot internally, no need to add yet another layer.

Fixes commit 72b51500f5d6 (".github/workflows: add first, new main.yml building on Ubuntu 24")