### PR TITLE
mkosi.arch: add pkgconf

### DIFF
--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -4,6 +4,7 @@ Packages=
   asciidoctor
   bash-completion
   cmake
+  pkgconf
   dhclient
   fio
   gcc


### PR DESCRIPTION
Required to compile ndctl