### PR TITLE
run_qemu.sh: default to the build OS like mkosi does instead of Fedora 40

### DIFF
--- a/mkosi_tmpl_portable/distro.tmpl
+++ b/mkosi_tmpl_portable/distro.tmpl
@@ -1,4 +1,4 @@
 [Distribution]
-Distribution=@OS_DISTRO@
-Release=@OS_RELEASE@
+@OS_DISTRIBUTION_DEF@
+@OS_RELEASE_DEF@
 


### PR DESCRIPTION
Using one distro to build another one is fraught with peril and most people just want to stick to the same OS. That's how mkosi behaves by default so let's align with that. It's annoying and time-consuming not to forget to tell run_qemu.sh what distribution it is currently running on.  That information is available in /etc/os-release so let's just read it and use it.

To simplify the run_qemu.sh behavior, do not set Distribution=$distro and Release=$rev in mkosi configuration if the user did not provide them. Let mkosi perform its unmodified magic.

Bonus feature: regularly bumping 40 to 41, 42, etc. is not required any more.