### PR TITLE
run_qemu.sh: add space before printf ' --timeout...' argument.

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -376,7 +376,7 @@ process_options_logic()
 	fi
 	if [[ $_arg_timeout -gt 0 ]]; then
 		if [[ ! -x "$qmp" ]]; then
-			fail "--timeout requires 'qmp'. $qmp not found"
+			fail " --timeout requires 'qmp'. $qmp not found"
 		fi
 		_arg_qmp="on"
 	fi


### PR DESCRIPTION
Fixes the following error

```
run_qemu.sh --cxl-test-run

run_qemu.sh: line 83: printf: --: invalid option
printf: usage: printf [-v var] format [arguments]
```

Fixes commit d347a49cab6a ("run_qemu.sh: changed fail() function to accept format arguments")