### PR TITLE
run_qemu.sh: restore ability to build without ndctl

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -15,7 +15,7 @@ pmem_label_size=2  #in MiB
 pmem_final_size="$((pmem_size + pmem_label_size))"
 : "${qemu:=qemu-system-x86_64}"
 : "${gdb:=gdb}"
-: "${ndctl:=$(readlink -f ~/git/ndctl)}"
+: "${ndctl=$(readlink -f ~/git/ndctl)}"
 selftests_home=root/built-selftests
 mkosi_bin="mkosi"
 mkosi_opts=("-i" "-f")
@@ -431,8 +431,9 @@ process_options_logic()
 	if [[ $_arg_kvm = "off" ]]; then
 		accel="tcg"
 	fi
-
-	check_ndctl_dir
+	if [[ $_arg_ndctl_build == "on" ]]; then
+		check_ndctl_dir
+	fi
 }
 
 make_install_kernel()


### PR DESCRIPTION
Fixes commit 1a2a679b8fcd ("run_qemu.sh: fail immediately when $ndctl is invalid")

My bad, I didn't realize `readlink -f $does_not_exist` prints "$does_not_exit", I assumed it prints nothing and I did not test enough combinations. So, that previous commit made it way too hard to disable the ndctl build: you must pass `--no-ndctl-build` _and_ have a valid `~/git/ndctl`?! This makes no sense.

Fix the logic so either a blank `ndctl=`, or  `--no-ndctl-build` is each enough to disable the ndctl build.