### PR TITLE
run_qemu.sh: update_existing_rootfs: pass -x to make_install_kernel

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -890,7 +890,11 @@ __update_existing_rootfs()
 	fi
 	sudo make "$mod_inst_param" $ims modules_install
 	sudo make INSTALL_HDR_PATH="$inst_prefix/usr" headers_install
-	sudo -E bash -c "$(declare -f make_install_kernel); make_install_kernel $inst_path"
+
+	if [[ $_arg_debug == 'on' ]]; then
+	    local _trace_sh='-x'
+	fi
+	sudo -E bash $_trace_sh -c "$(declare -f make_install_kernel); make_install_kernel $inst_path"
 
 	if [[ $_arg_cxl_test == "off" ]]; then
 		sudo rm -f "$inst_prefix"/usr/lib/modules/"$kver"/extra/cxl_*.ko
@@ -910,9 +914,6 @@ __update_existing_rootfs()
 		sudo rm -rf "$selftests_dir"
 	fi
 
-	if [[ $_arg_debug == 'on' ]]; then
-	    local _trace_sh='-x'
-	fi
 	sudo -E bash $_trace_sh -c "$(declare -f setup_depmod); _arg_nfit_test=$_arg_nfit_test; _arg_cxl_test=$_arg_cxl_test; kver=$kver; setup_depmod $inst_prefix"
 	sudo -E bash $_trace_sh -c "$(declare -f setup_autorun); _arg_autorun=$_arg_autorun; setup_autorun $inst_prefix"
 

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -439,6 +439,11 @@ make_install_kernel()
 {
 	local inst_path="$1"
 
+	test -n "$kver" || { # can't use fail() when inlined with declare -f
+		>&2 printf 'ERROR: Undefined $kver in make_install_kernel()\n'
+		exit 1
+	}
+
 	cat arch/x86_64/boot/bzImage > "$inst_path"/vmlinuz-"$kver"
 	cp System.map "$inst_path"/System.map-"$kver"
 	ln -fs "$inst_path"/vmlinuz-"$kver" "$inst_path"/vmlinuz
@@ -894,7 +899,7 @@ __update_existing_rootfs()
 	if [[ $_arg_debug == 'on' ]]; then
 	    local _trace_sh='-x'
 	fi
-	sudo -E bash $_trace_sh -e -c "$(declare -f make_install_kernel); make_install_kernel $inst_path"
+	sudo -E bash $_trace_sh -e -c "$(declare -f make_install_kernel); kver=$kver make_install_kernel $inst_path"
 
 	if [[ $_arg_cxl_test == "off" ]]; then
 		sudo rm -f "$inst_prefix"/usr/lib/modules/"$kver"/extra/cxl_*.ko

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -894,7 +894,7 @@ __update_existing_rootfs()
 	if [[ $_arg_debug == 'on' ]]; then
 	    local _trace_sh='-x'
 	fi
-	sudo -E bash $_trace_sh -c "$(declare -f make_install_kernel); make_install_kernel $inst_path"
+	sudo -E bash $_trace_sh -e -c "$(declare -f make_install_kernel); make_install_kernel $inst_path"
 
 	if [[ $_arg_cxl_test == "off" ]]; then
 		sudo rm -f "$inst_prefix"/usr/lib/modules/"$kver"/extra/cxl_*.ko


### PR DESCRIPTION
3 commits.

Main one: Stops creating bogus vmlinuz- and System.map- files.


Bug fix related to #88. Does NOT address the complex 88 issue but removes some confusion from it.