### PR TITLE
run_qemu.sh: remove 'sleep 5' after 'sync'

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -647,7 +647,6 @@ umount_rootfs()
 	looppart="${loopdev}p${partnum}"
 
 	sync
-	sleep 5
 	sudo umount "$looppart"
 	sudo rm -rf "$mp"
 	sudo losetup -d "$loopdev"


### PR DESCRIPTION
remove sleep 5 after 'sync' in umount_rootfs()

'sync' means 'sync': it is blocking so there's no need for a random delay.

Fixes commit ee43cb8a9d1b ("run_qemu: fix occasional umount failures") which added both at the same time.