### PR TITLE
run_qemu.sh: delay get_ovmf_binaries() until actual use

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1642,8 +1642,8 @@ main()
 			;;
 	esac
 
-	prepare_qcmd
 	if [[ $_arg_run == "on" ]]; then
+		prepare_qcmd
 		start_qemu
 	fi
 	if [[ $_arg_post_script ]]; then

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1470,6 +1470,7 @@ prepare_qcmd()
 		qcmd+=("-serial" "file:$_arg_log")
 	fi
 	if [[ $_arg_legacy_bios == "off" ]] ; then
+		get_ovmf_binaries
 		qcmd+=("-drive" "if=pflash,format=raw,unit=0,file=OVMF_CODE.fd,readonly=on")
 		qcmd+=("-drive" "if=pflash,format=raw,unit=1,file=OVMF_VARS.fd")
 		qcmd+=("-debugcon" "file:uefi_debug.log" "-global" "isa-debugcon.iobase=0x402")
@@ -1569,8 +1570,6 @@ prepare_qcmd()
 start_qemu()
 {
 	pushd "$builddir" > /dev/null || exit 1
-
-	get_ovmf_binaries
 
 	if [[ $_arg_log ]]; then
 		if (( _arg_quiet < 3 )); then


### PR DESCRIPTION
This goes one step further than previous commit
8504b014d7e6 ("run_qemu.sh: move get_ovmf_binaries() later, to
start_qemu()")

Do not look for OVMF binaries when --legacy-bios.

This is not so much about --legacy-bios but rather to regroup all
OVMF-related stuff in a single place and makes it easier to temporarily
disable OVMF locally. For instance: when using --direct-kernel which is
the default. And yes: the image can boot with --direct-kernel and no
OVMF at all. Whether that's a good idea or not is a different question -
but it's sometimes useful as a local test hack.
