### PR TITLE
run_qemu.sh: drop dracut --filesystems="xfs ext4" parameter

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -471,7 +471,6 @@ install_build_initrd()
 		--no-hostonly \
 		--show-modules \
 		--kver="$kver" \
-		--filesystems="xfs ext4" \
 		--kmoddir "$inst_prefix/lib/modules/$kver/" \
 		--kernel-image "./vmlinux" \
 		--add "bash systemd kernel-modules fs-lib" \


### PR DESCRIPTION
The purpose of the --filesystems= parameter is a bit counter-intuitive: it's designed to _reduce_ the size of the initrd by excluding all modules except the ones given.

```
man dracut
       --filesystems <list of filesystems>

           Specify a space-separated list of kernel filesystem modules
           to EXCLUSIVELY include in the generic initramfs.
```
Emphasis mine.

So, the previous "xfs ext4" argument could prevent someone with another filesystem module to boot.

Worse: if CONFIG_XFS_FS is false, then passing "xfs ext4" prints the following warning:

```
dracut-install: Failed to find module 'xfs'
dracut[E]: FAILED:  /usr/lib/dracut/dracut-install -D
  /var/tmp/dracut.eRkJZX/initramfs -N ^nfit$|^libnvdimm$|^nd_pmem$
  --kerneldir ./qbuild/mkosi.extra/lib/modules/6.12.0-dirty -m xfs ext4

```
Then, dracut does not include ext4 either and keeps running! So, users with CONFIG_EXT4_FS=m can't boot either!

Most users probably use built-in drivers which means they never notice.