### PR TITLE
mkosi: add "rsync" to Arch and Ubuntu

### DIFF
--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -38,6 +38,7 @@ Packages=
   meson
   util-linux
   hwloc
+  rsync
   systemd
   tree
   vi

--- a/mkosi.ubuntu.default.tmpl
+++ b/mkosi.ubuntu.default.tmpl
@@ -30,4 +30,5 @@ Packages=
   libtracefs-dev
   libtraceevent-dev
   libsystemd-dev
+  rsync
   meson


### PR DESCRIPTION
Very useful to move files between host and guest.

No reason only for Fedora to have it.