### PR TITLE
run_qemu.sh: add !#/bin/sh shebang for mkosi.postinst

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1004,6 +1004,7 @@ prepare_ndctl_build()
 	cp "${script_dir}"/mkosi/extra/root/ndctl/reinstall.sh \
 		mkosi.extra/root/ndctl/
 	cat <<- 'EOF' > mkosi.postinst
+		#!/bin/sh
 		# v14: 'systemd-nspawn"; v15: "mkosi"
 		printf 'container=%s\n' "$container"
 		# .postinst and others moved outside container in mkosi v15, see


### PR DESCRIPTION
Critical fix for mkosi versions v25 and above that include massive change commit b3a3e7e7fcb2 ("Introduce mkosi-sandbox and stop using subuids for image builds")

Fixes the following failure:
```
Running postinstall script kernel/qbuild/mkosi.postinst
Traceback (most recent call last):
  File "mkosi/mkosi/sandbox.py", line 924, in <module>
  File "mkosi/mkosi/sandbox.py", line 913, in main
  File "<frozen os>", line 609, in execvp
  File "<frozen os>", line 632, in _execvpe
OSError: [Errno 8] Exec format error
"/work/postinst final" returned non-zero exit code 1.
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>