### PR TITLE
run_qemu.sh: stop --cxl-test-run from forcing --cxl QEMU devices

### DIFF
--- a/parser_generator.m4
+++ b/parser_generator.m4
@@ -29,7 +29,7 @@ exit 11  #)Created by argbash-init v2.9.0
 # ARG_OPTIONAL_BOOLEAN([cxl-debug], , [Enable 'dyndbg' for CXL modules.], )
 # ARG_OPTIONAL_SINGLE([cxl-pmems], , [Number of QEMU CXL memdevs with pmem (0-4). Rest will default to volatile], [2])
 # ARG_OPTIONAL_BOOLEAN([cxl-test], , [Setup an environment for CXL unit tests\n. Include CXL 'extra' modules to mock a CXL hierarchy using the kernel's 'cxl_test' facility], )
-# ARG_OPTIONAL_BOOLEAN([cxl-test-run], , [CXL unit test mode. Implies the following: cxl\n cxl-debug\n cxl-test\n autorun=rq_cxl_tests.sh\n log=/tmp/rq_<instance>.log\n post-script=rq_cxl_results.sh\n timeout=5\n Non-boolean parameters above can be overridden by manually supplying the corresponding option(s)\n], )
+# ARG_OPTIONAL_BOOLEAN([cxl-test-run], , [CXL unit test mode. Implies the following:\n cxl-debug\n cxl-test\n autorun=rq_cxl_tests.sh\n log=/tmp/rq_<instance>.log\n post-script=rq_cxl_results.sh\n timeout=5\n Non-boolean parameters above can be overridden by manually supplying the corresponding option(s)\n], )
 # ARG_OPTIONAL_BOOLEAN([dax-debug], , [Enable 'dyndbg' for DAX modules.], )
 # ARG_OPTIONAL_BOOLEAN([debug], [v], [Debug script problems (enables set -x)], )
 # ARG_OPTIONAL_BOOLEAN([ndctl-build], , [Enable ndctl build in root image], [on])

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -326,7 +326,6 @@ process_options_logic()
 		set -x
 	fi
 	if [[ $_arg_cxl_test_run == "on" ]]; then
-		_arg_cxl="on"
 		_arg_cxl_debug="on"
 		_arg_cxl_test="on"
 		if [[ ! $_arg_autorun ]]; then


### PR DESCRIPTION
QEMU devices are not required to run cxl tests, so let the user decide what they want.

Autorun has very recently been fixed (commit 17d0473a629a and others in PR #101) and had been broken for likely 1 or 2 years which means no one was using it which means it's a great time to alter the behavior.