### PR TITLE
.github: new cxl-test.cfg from ndctl/README.md; add --cxl-test

### DIFF
--- a/.github/workflows/cxl-test.cfg
+++ b/.github/workflows/cxl-test.cfg
@@ -1,0 +1,48 @@
+# Fragment tested with kernel v6.13 + make defconfig ARCH=x86_64
+
+# FIXME : this file is not enough to PASS all --suite=cxl tests yet
+# but it is already enough to automatically build and run.
+
+
+# Requirements missing from ndctl.git/README.md as of ndctl v80
+
+CONFIG_MEMORY_HOTPLUG=y
+CONFIG_MEMORY_HOTREMOVE=y
+
+
+# Duplicate of ndctl.git/README.md as of ndctl v80.
+
+# libnvdimm requirements
+CONFIG_X86_PMEM_LEGACY=m
+CONFIG_ZONE_DEVICE=y
+CONFIG_LIBNVDIMM=m
+CONFIG_BLK_DEV_PMEM=m
+CONFIG_BTT=y
+CONFIG_NVDIMM_PFN=y
+CONFIG_NVDIMM_DAX=y
+CONFIG_DEV_DAX_PMEM=m
+CONFIG_ENCRYPTED_KEYS=y
+CONFIG_NVDIMM_SECURITY_TEST=y
+CONFIG_STRICT_DEVMEM=y
+CONFIG_IO_STRICT_DEVMEM=y
+
+# CXL test requirements
+CONFIG_CXL_BUS=m
+CONFIG_CXL_PCI=m
+CONFIG_CXL_ACPI=m
+
+CONFIG_CXL_PMEM=m
+CONFIG_CXL_MEM=m
+CONFIG_CXL_PORT=m
+CONFIG_CXL_REGION=y
+CONFIG_CXL_REGION_INVALIDATION_TEST=y
+CONFIG_DAX=m
+CONFIG_TRANSPARENT_HUGEPAGE=y
+CONFIG_DEV_DAX=m
+CONFIG_DEV_DAX_CXL=m
+
+
+# Optimization: saves almost half the compilation time with just one
+# one-line. When making and testing changes above, comment out this line
+# to make the output of kconfig/merge_config.sh usable.
+CONFIG_DRM=n

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
             img_distro: ubuntu
             img_rel: noble
         arch: [x86_64]
-        run_opts: [--cxl --ndctl-build]
+        run_opts: [--cxl-test --ndctl-build]
 
     steps:
       - uses: actions/checkout@v4
@@ -133,8 +133,10 @@ jobs:
             ${{ matrix.cfg.os }}_${{ matrix.arch }}
 
       - name: defconfig
-        run: cd kernel &&
+        working-directory: ${{ github.workspace }}/kernel
+        run: |
           make defconfig ARCH=${{ matrix.arch }}
+          ./scripts/kconfig/merge_config.sh .config ../run_qemu/.github/workflows/cxl-test.cfg
 
       - name: disable AppArmor
         run: |


### PR DESCRIPTION
Now making sure that --cxl-test builds tests from ndctl.

New .github/workflows/cxl-test.cfg based on ndctl.git/README.md.

Still --no-run cause running in a Github runner VM.

Also drop --cxl which was a misunderstanding: this merely configures QEMU which is not used here.