### PR TITLE
run_qemu.sh: drop mkosi --autologin, use systemd credentials instead

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -729,6 +729,14 @@ build_kernel_cmdline()
 			"efi_fake_mem=2G@10G:0x40000"
 		)
 	fi
+	if [[ $_arg_gcp == "off" ]]; then
+		# https://systemd.io/CREDENTIALS/
+		# This requires systemd v251 or above (commit 4b9a4b017, April 2022)
+		kcmd+=(
+			systemd.set_credential=agetty.autologin:root
+			systemd.set_credential=login.noauth:yes
+		)
+	fi
 
 	tot_mem="$(((_arg_mem_size / 1024) * (num_mems + num_nodes)))"  # in GiB
 	if (( num_legacy_pmems > 0 )); then
@@ -1188,10 +1196,6 @@ make_rootfs()
 
 	setup_depmod "mkosi.extra"
 	setup_autorun "mkosi.extra"
-
-	if [[ $_arg_gcp == "off" ]]; then
-		mkosi_opts+=("--autologin")
-	fi
 
 	if [[ $_arg_debug == "on" ]]; then
 	    # In case of yet another mkosi incompatibility or other issue,


### PR DESCRIPTION
Until mkosi v24 commit c236c9f7b9c82d3, `mkosi --autologin` used to be applied to four devices: console, tty1, ttyS0 and one architecture-dependent device.

mkosi has some QEMU features of its own to boot the image. run_qemu.sh never used any of that. We should probably try (some of) it in the future but I digress. In that mkosi commit, `mkosi/qemu.py` (which we don't use) stopped using `ttyS0` and replaced it with the faster `/dev/hvc0` instead. The image building code (which we DO use!) was updated correspondingly without caring about backwards compatibility and dropped ttyS0 on the floor. Someone noted this in
https://github.com/systemd/mkosi/pull/2834 and the recommendation was to switch to systemd credentials: exactly what this commit does. The mkosi maintainer also expressed the possible removal of `--autologin` in the future.

Pros:
- Completely removes the autologin dependency on the changing mkosi behavior. Compatible with any mkosi version.
- Applies to all terminals, zero hardcoded name.
- Simpler, clearer and more direct implementation: zero configuration file!
- More dynamic: changes and tests do not require rebuilding anything.

Cons:
- Requires systemd v251 or above (May 2022)
- Applies to all terminals but could be more selective when using "per-instance" systemd credentials added in v257 (December 2024)