### PR TITLE
mkosi.arch.default.tmpl: add python-pip

### DIFF
--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -1,4 +1,5 @@
 [Content]
+# To use pacman, run this first: pacman-key --init && pacman-key --populate
 Packages=
   pacman
   archlinux-keyring
@@ -30,6 +31,9 @@ Packages=
   perl
   procps-ng
   python
+  python-pip
+  python-pipx
+  python-prefixed
   strace
   sudo
   util-linux


### PR DESCRIPTION
Also add `python-prefixed` that can pretty-print large addresses.