### PR TITLE
mkosi.arch.default.tmpl: add pciutils

### DIFF
--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -27,6 +27,7 @@ Packages=
   neovim
   net-tools
   numactl
+  pciutils
   openssh
   perl
   procps-ng


### PR DESCRIPTION
I think we can agree that `lspci` is somewhat useful for CXL.