### PR TITLE
Clean up the addition of extra directories and/or files

### DIFF
--- a/parser_generator.m4
+++ b/parser_generator.m4
@@ -34,6 +34,7 @@ exit 11  #)Created by argbash-init v2.9.0
 # ARG_OPTIONAL_BOOLEAN([debug], [v], [Debug script problems (enables set -x)], )
 # ARG_OPTIONAL_BOOLEAN([ndctl-build], , [Enable ndctl build in root image], [on])
 # ARG_OPTIONAL_BOOLEAN([kern-selftests], , [Enable kernel selftest build in root image (Warning: This option can take a long time and requires many support packages on the host; including some 32 bit)], [off])
+# ARG_OPTIONAL_SINGLE([extra-dirs], , [Specify a file with a list of directories (or files) to be copied to the /root directory within the image.], [])
 # ARG_OPTIONAL_INCREMENTAL([quiet], [q], [quieten some output, can be repeated multiple times to quieten even more], )
 # ARG_OPTIONAL_BOOLEAN([gdb], , [Wait for gdb to connect for kernel debug (port 10000)], )
 # ARG_OPTIONAL_BOOLEAN([gdb-qemu], , [Start qemu with gdb], )

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1125,6 +1125,7 @@ make_rootfs()
 		process_mkosi_template "$tmpl" > "$dst"
 	done
 
+	# Add user space items from host
 	rsync -a "${script_dir}"/mkosi/extra/  mkosi.extra/
 
 	# misc rootfs setup
@@ -1147,10 +1148,6 @@ make_rootfs()
 	fi
 	if [ -f ~/.vimrc ]; then
 		rsync "${rsync_opts[@]}" ~/.vim* mkosi.extra/root/
-	fi
-	mkdir -p mkosi.extra/root/bin
-	if [ -d ~/git/extra-scripts ]; then
-		rsync "${rsync_opts[@]}" ~/git/extra-scripts/bin/* mkosi.extra/root/bin/
 	fi
 	if [[ $_arg_ndctl_build == "on" ]]; then
 		if [ -n "$ndctl" ]; then


### PR DESCRIPTION
The ability to add random files and directories to the root image had previously been hacked in via a secret 'special' directory location.  This functionality is nice but lacking for a couple of reasons.

1) It is undocumented so even the original author forgot about its existence
2) It provides little flexibility

Remove the existing hidden feature and add --extra-dirs as a parameter which can specify a list of directories (or files) to be added to /root within the image.

This functionality was discussed in https://github.com/pmem/run_qemu/issues/124

This does not remove or clean up the rsync's but should make one of it's uses much more clear.

To ensure explicit usage for the user no default is provided.  But directories will not be removed without a -r wipe.