### PR TITLE
Packages: add sshfs

### DIFF
--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -17,6 +17,7 @@ Packages=
   iniparser
   inetutils
   iproute2
+  iputils
   jq
   kmod
   libtraceevent
@@ -29,6 +30,7 @@ Packages=
   numactl
   pciutils
   openssh
+  sshfs
   perl
   procps-ng
   python

--- a/mkosi.fedora.default.tmpl
+++ b/mkosi.fedora.default.tmpl
@@ -2,6 +2,7 @@
 Packages=
   openssh-clients
   openssh-server
+  fuse-sshfs
   httpd
   ndctl
   daxctl

--- a/mkosi.ubuntu.default.tmpl
+++ b/mkosi.ubuntu.default.tmpl
@@ -2,6 +2,7 @@
 Packages=
   ndctl
   openssh-client
+  sshfs
   lsof
   strace
   ltrace


### PR DESCRIPTION
This allows the guest to mount any host directory "out of the box" with zero qemu or kernel feature to enable.  Thanks to `dpipe` and "reverse sshfs", this does not require any additional ssh configuration either:

https://blog.dhampir.no/content/reverse-sshfs-mounts-fs-push
```
dpipe /usr/lib/openssh/sftp-server = ssh CLIENT sshfs :/mnt/host/path /mnt/client/path -o slave
```

This Just Works out of the box.

Just for the record, virtiofs and 9P are the most popular and likely much faster alternatives but sshfs is "good enough" in most cases. virtiofs seems to clash with what we already do ("NUMA distance missing" error, etc.) and 9P is rumoured to be quite slow too.

Also add "ping" and friends on Arch Linux.