### PR TITLE
run_qemu.sh: use `set -x` to always log the qemu command

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1628,7 +1628,9 @@ start_qemu()
 		fi
 	fi
 	if [[ $_arg_timeout == "0" ]]; then
+	( set -x
 		"${qcmd[@]}"
+	)
 	else
 		printf "guest will be terminated after %d minute(s)\n" "$_arg_timeout"
 		"${qcmd[@]}" & sleep 5


### PR DESCRIPTION
This is the most complex and most important command: the name of this whole git repo is "run_qemu"!

This leaves a failing qemu command visible on the terminal.

When the qemu command does not fail, it's drown by all the other messages and barely visible in the logs.