### PR TITLE
run_qemu.sh: fix --no-kvm option

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -429,10 +429,6 @@ process_options_logic()
 	fi
 	num_cxl_vmems="$((4 - num_cxl_pmems))"
 
-	if [[ $_arg_kvm = "off" ]]; then
-		accel="tcg"
-	fi
-
 	# For legacy reasons the "$ndctl" variable has been the "real" switch
 	# as --ndctl-build is ON by default - and true most of the time.
 	if [ -n "$ndctl" ]; then
@@ -1506,6 +1502,9 @@ prepare_qcmd()
 	qcmd+=("$qemu")
 
 	# setup machine_args
+	if [[ $_arg_kvm = "off" ]]; then
+		accel="tcg" # the default
+	fi
 	machine_args=("q35" "accel=$accel")
 	if [[ "$num_pmems" -gt 0 ]]; then
 		machine_args+=("nvdimm=on")

--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1492,7 +1492,11 @@ prepare_qcmd()
 	# cpu topology: num_nodes sockets, 2 cores per socket, 2 threads per core
 	# so smp = num_nodes (sockets) * cores * threads
 	cores=2
-	threads=2
+	if [[ $_arg_kvm == "on" ]]; then
+		threads=2
+	else
+		threads=1
+	fi
 	sockets=$num_nodes
 	smp=$((sockets * cores * threads))
 
@@ -1545,8 +1549,11 @@ prepare_qcmd()
 
 	qcmd+=("-device" "e1000,netdev=net0,mac=$mac_addr")
 	qcmd+=("-netdev" "user,id=net0,hostfwd=tcp::$hostport-:22")
+
+	if [[ $_arg_kvm = "on" ]]; then
 	# Use host CPU capability
-	qcmd+=("-cpu" "host")
+		qcmd+=("-cpu" "host")
+	fi
 
 	if [[ $_arg_cxl == "on" ]]; then
 		setup_cxl


### PR DESCRIPTION
2 commits. Main one:

Fixes commit https://github.com/pmem/run_qemu/commit/ff1ece56dbca7feeaa624578762b0b2c31f80026 ("run_qemu.sh: use host CPU capability to
avoid guest boot failed issue")

"-cpu host" requires KVM.

Hyperthreading requires recent CPUs.