### PR TITLE
mkosi.arch.default.tmpl: add systemd-sysvcompat to fix --no-direct-kernel

### DIFF
--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -47,5 +47,6 @@ Packages=
   hwloc
   rsync
   systemd
+  systemd-sysvcompat
   tree
   vi


### PR DESCRIPTION
This provides... the /sbin/init symbolic link which is required to boot with --no-direct-kernel!