### PR TITLE
Add new aamvf_path variable in ubuntu_vars.sh file

### DIFF
--- a/debian_vars.sh
+++ b/debian_vars.sh
@@ -3,3 +3,4 @@
 # Copyright (C) 2023 Intel Corporation. All rights reserved.
 
 ovmf_path="/usr/share/OVMF/"
+aavmf_path="/usr/share/AAVMF/"

--- a/fedora_vars.sh
+++ b/fedora_vars.sh
@@ -3,3 +3,4 @@
 # Copyright (C) 2023 Intel Corporation. All rights reserved.
 
 ovmf_path="/usr/share/edk2/ovmf/"
+aavmf_path="/usr/share/AAVMF"


### PR DESCRIPTION
Ubuntu's arm64 port, at least 24.10, packages EFI binaries the /usr/share/AAVMF directory. Add a new variable, aavmf_path in ubuntu_vars.sh, depending on the arch, run_qemu.sh can pick up the appropriate "path" to the EFI binaries.