### PR TITLE
Pick arm64 also for the Workflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           - os: ubuntu-24.04
             img_distro: ubuntu
             img_rel: noble
-        arch: [x86_64]
+        arch: [x86_64, arm64]
         run_opts: [--cxl-test --ndctl-build]
 
     steps:


### PR DESCRIPTION
This can be pulled when major changes to the run_qemu.sh script are pulled.