### PR TITLE
Add a new function get_aavmf_binaries()

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1362,6 +1362,22 @@ get_ovmf_binaries()
 	fi
 }
 
+get_aavmf_binaries()
+{
+       if [[ ! $aavmf_path ]]; then
+               echo "Unable to determine AAVMF path for $_distro"
+               exit 1
+        fi
+       if ! [ -e "AAVMF_CODE.fd" ] && ! [ -e "AAVMF_VARS.fd" ]; then
+                if [ ! -f "$aavmf_path/AAVMF_CODE.fd" ]; then
+                        echo "AAVMF binaries not found, please install '[edk2-]ovmf' or similar, 'edk2-shell', ..."
+                        exit 1
+                fi
+                cp "$aavmf_path/AAVMF_CODE.fd" .
+                cp "$aavmf_path/AAVMF_VARS.fd" .
+       fi
+}
+
 setup_nvme()
 {
 	local num="$1"


### PR DESCRIPTION
so that EFI binaries are copied over to the build directory if they are located in /usr/share/AAVMF.