### PR TITLE
Add pciutils package to the Ubuntu list

### DIFF
--- a/mkosi.ubuntu.default.tmpl
+++ b/mkosi.ubuntu.default.tmpl
@@ -35,6 +35,7 @@ Packages=
   libtraceevent-dev
   libsystemd-dev
   rsync
+  pciutils
   meson
   # These below have evolved between Ubuntu 22.04 and 24.04
   # ?(exact-name ...) is used as a trick not to fail when it's missing.


### PR DESCRIPTION
I've tested the package builtd properly and lspci worked in the aarch64 VM. Please pull.