### PR TITLE
ubuntu-ESP.tmpl: switch to a Release=! negation for 25.04

### DIFF
--- a/mkosi_tmpl_from_v15/ubuntu-ESP.tmpl
+++ b/mkosi_tmpl_from_v15/ubuntu-ESP.tmpl
@@ -3,8 +3,8 @@
 
 [Match]
 Distribution=ubuntu
-Release=|noble
-Release=|oracular
+# Until 22.04 jammy, there was no separate 'systemd-boot' package.
+Release=!jammy
 
 # Some mkosi versions do not automatically download this, even when Bootable=yes
 [Content]


### PR DESCRIPTION
Rather than constantly growing the list of releases that need systemd-boot, list the only we support that does not have it.