### PR TITLE
run_qemu.sh: un-hardcode /dev/sda2 in QEMU parameters

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1627,7 +1627,11 @@ prepare_qcmd()
 {
 	# this step may expect files to be present at the toplevel, so run
 	# it before dropping into the builddir
-	build_kernel_cmdline "/dev/sda2"
+	mount_rootfs 2
+	local root_partuuid; root_partuuid=$(get_partuuid "${loopdev}" 2)
+	umount_rootfs 2
+
+	build_kernel_cmdline "PARTUUID=${root_partuuid}"
 
 	pushd "$builddir" > /dev/null || exit 1
 


### PR DESCRIPTION
Fixes #137. Hardcoding also reported in #140

Leverages old code already used by /efi and --no-direct-kernel.

This commit affects only --direct-kernel