### PR TITLE
.github: main.yml: add on.workflow_call

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ name: main test
 # 'workflow_dispatch' allows running this workflow manually from the
 # 'Actions' tab
 # yamllint disable-line rule:truthy
-on: [pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch, workflow_call]
 
 jobs:
   build:


### PR DESCRIPTION
Required for new scheduled.yml to invoke it.

As reported in https://github.com/pmem/run_qemu/actions/runs/14606426775

Invalid workflow file: .github/workflows/scheduled.yml#L23 error parsing called workflow
".github/workflows/scheduled.yml"
-> "./.github/workflows/main.yml" (source branch with sha:b80bd6904c...) : workflow is not reusable as it is missing a `on.workflow_call` trigger