### PR TITLE
run_qemu.sh: explicitly define hugepages for hugetlb unit test

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -826,6 +826,7 @@ build_kernel_cmdline()
 		kcmd+=( 
 			"memmap=3G!6G,1G!9G"
 			"efi_fake_mem=2G@10G:0x40000"
+			"default_hugepagesz=1G hugepagesz=1G hugepages=2"
 		)
 	fi
 	if [[ $_arg_gcp == "off" ]]; then


### PR DESCRIPTION
Starting with kernel v6.11 it became necessary to explicitly define the hugepages wanted [1]. Without that explicit request the hugetlb unit test has been skipping at runtime when it's unable to alloc a 1G page.

Request the hugepages on the cmdline when nfit_test is selected.

[1] https://lore.kernel.org/all/20211005054729.86457-1-yaozhenguo1@gmail.com/