### PR TITLE
run_qemu.sh: do not automatically modprobe 'cxl_test' at boot time

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1032,8 +1032,6 @@ setup_depmod()
 	depmod_dir="$prefix/etc/depmod.d"
 	depmod_conf="$depmod_dir/nfit_test.conf"
 	depmod_cxl_conf="$depmod_dir/cxl_test.conf"
-	depmod_load_dir="$prefix/etc/modules-load.d"
-	depmod_load_cxl_conf="$depmod_load_dir/cxl_test.conf"
 
 	if [[ $_arg_nfit_test == "on" ]]; then
 		mkdir -p "$depmod_dir"
@@ -1062,13 +1060,8 @@ setup_depmod()
 			override cxl_mem * extra
 			override cxl_port * extra
 		EOF
-		mkdir -p "$depmod_load_dir"
-		cat <<- EOF > "$depmod_load_cxl_conf"
-			cxl_test
-		EOF
 	else
 		rm -f "$depmod_cxl_conf"
-		rm -f "$depmod_load_cxl_conf"
 	fi
 	system_map="$prefix/boot/System.map"
 	if [ ! -f "$system_map" ]; then


### PR DESCRIPTION
Boot time is not a good time to debug issues like
https://github.com/pmem/ndctl/issues/278 or any other really.

`git -C ndctl/ grep 'modprobe.*cxl_test'` shows that pretty much every test already loads and unloads cxl_test by itself. If some exotic test managed to avoid doing this until today, then falling back in line is overdue.

PS: the "depmod_load_..." variable names were wrong: this was relying on systemd, not depmod.