### PR TITLE
.github: upload test logs on failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,6 +181,7 @@ jobs:
                  ../run_qemu/run_qemu.sh ${{ matrix.run_opts }} --no-kvm
 
       - name: upload test logs
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: logs ${{ matrix.cfg.os }}


### PR DESCRIPTION
Upload test logs when they are the most useful.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>
@marc-hb