### PR TITLE
rq_cxl_tests.sh: quote new $NDCTL expansion

### DIFF
--- a/scripts/rq_cxl_tests.sh
+++ b/scripts/rq_cxl_tests.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: CC0-1.0
 # Copyright (C) 2021 Intel Corporation. All rights reserved.
 
-: ${NDCTL:=/root/ndctl}
+: "${NDCTL:=/root/ndctl}"
 
 cleanup()
 {


### PR DESCRIPTION
Fixes shellcheck warning just introduced.