### PR TITLE
run_qemu.sh: run mkdir _after_ "make kernelrelease"

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -617,11 +617,6 @@ __build_kernel()
 		quiet="--quiet"
 	fi
 
-	mkdir -p "$inst_path"
-	# /lib -> /usr/lib
-	mkdir -p "${inst_prefix}/usr/lib"
-	ln -sf usr/lib "${inst_prefix}/lib"
-
 	if [[ $_arg_defconfig == "on" ]]; then
 		make $quiet olddefconfig
 		make $quiet prepare
@@ -629,6 +624,11 @@ __build_kernel()
 	kver=$(make -s kernelrelease)
 	test -n "$kver"
 	make $quiet -j"$num_build_cpus"
+
+	mkdir -p "$inst_path"
+	# /lib -> /usr/lib
+	mkdir -p "${inst_prefix}/usr/lib"
+	ln -sf usr/lib "${inst_prefix}/lib"
 
 	# Install Modules Strip = ims
 	local ims=""


### PR DESCRIPTION
"make kernelrelease" is the first command that fails when run_qemu.sh is run in the wrong directory. Detect we're run in a wrong directory _before_ creating various build directories, this avoids having to clean them up.