### PR TITLE
.github/workflows/cxl-test.cfg: remove NVDIMM requirements not needed

### DIFF
--- a/.github/workflows/cxl-test.cfg
+++ b/.github/workflows/cxl-test.cfg
@@ -1,32 +1,16 @@
-# Fragment tested with kernel v6.13 + make defconfig ARCH=x86_64
-
-# FIXME : this file is not enough to PASS all --suite=cxl tests yet
-# but it is already enough to automatically build and run.
-
-
-# Requirements missing from ndctl.git/README.md as of ndctl v80
-
-CONFIG_MEMORY_HOTPLUG=y
-CONFIG_MEMORY_HOTREMOVE=y
-
-
-# Duplicate of ndctl.git/README.md as of ndctl v80.
-
-# libnvdimm requirements
-CONFIG_X86_PMEM_LEGACY=m
-CONFIG_ZONE_DEVICE=y
-CONFIG_LIBNVDIMM=m
-CONFIG_BLK_DEV_PMEM=m
-CONFIG_BTT=y
-CONFIG_NVDIMM_PFN=y
-CONFIG_NVDIMM_DAX=y
-CONFIG_DEV_DAX_PMEM=m
-CONFIG_ENCRYPTED_KEYS=y
-CONFIG_NVDIMM_SECURITY_TEST=y
-CONFIG_STRICT_DEVMEM=y
-CONFIG_IO_STRICT_DEVMEM=y
-
 # CXL test requirements
+
+# Fragment tested with kernel v6.15 and:
+#
+#    make defconfig ARCH=x86_64
+#    ./scripts/kconfig/merge_config.sh .config $this_file
+
+# WARNING: you may or may not need to disable KASLR, see issue
+# https://github.com/pmem/ndctl/issues/278
+
+
+# This first section is mostly a duplicate of ndctl.git/README.md as of ndctl v81
+# Try to keep both in sync.
 CONFIG_CXL_BUS=m
 CONFIG_CXL_PCI=m
 CONFIG_CXL_ACPI=m
@@ -43,6 +27,25 @@ CONFIG_DEV_DAX_CXL=m
 
 # --cxl-debug requirement (part of --cxl-test-run)
 CONFIG_DYNAMIC_DEBUG=y
+
+
+# These CXL test requirements are either directly in the libnvdimm
+# section of ndctl.git/README.md, or indirect dependencies of it.
+
+# Required by CXL_PMEM
+CONFIG_LIBNVDIMM=m
+
+# Needed by ndctl/test/cxl-security.sh specifically
+CONFIG_ENCRYPTED_KEYS=y
+CONFIG_NVDIMM_KEYS=y
+CONFIG_NVDIMM_SECURITY_TEST=y
+
+
+# These are required by DEV_DAX_PMEM, NVDIMM_DAX and a couple others
+# below but missing from ndctl.git/README.md as of ndctl v81
+CONFIG_MEMORY_HOTPLUG=y
+CONFIG_MEMORY_HOTREMOVE=y
+
 
 # Optimization: saves almost half the compilation time with just one
 # one-line. When making and testing changes above, comment out this line


### PR DESCRIPTION
Trim down the nvdimm section copied from ndctl.git/README.md, remove requirements not required by the CXL test suite.