### PR TITLE
ubuntu/arch: add trace-cmd, xxd and parted packages

### DIFF
--- a/mkosi.arch.default.tmpl
+++ b/mkosi.arch.default.tmpl
@@ -49,5 +49,8 @@ Packages=
   rsync
   systemd
   systemd-sysvcompat
+  parted
+  tinyxxd
+  trace-cmd
   tree
   vi

--- a/mkosi.fedora.default.tmpl
+++ b/mkosi.fedora.default.tmpl
@@ -71,6 +71,7 @@ Packages=
   ninja-build
   vbindiff
   trace-cmd
+  xxd
   libtraceevent
   libtraceevent-devel
   libtracefs

--- a/mkosi.ubuntu.default.tmpl
+++ b/mkosi.ubuntu.default.tmpl
@@ -36,6 +36,9 @@ Packages=
   libsystemd-dev
   rsync
   pciutils
+  parted
+  trace-cmd
+  xxd
   meson
   # These below have evolved between Ubuntu 22.04 and 24.04
   # ?(exact-name ...) is used as a trick not to fail when it's missing.


### PR DESCRIPTION
Needed by some ndctl/dax tests.

Fixes: 2e450c06e (run_qemu: add asciidoc and trace-cmd to the fedora template)