### PR TITLE
.github: add new nfit-test.cfg

### DIFF
--- a/.github/workflows/nfit-test.cfg
+++ b/.github/workflows/nfit-test.cfg
@@ -1,0 +1,44 @@
+# nfit test requirements
+
+# Fragment tested with kernel v6.15 and:
+#
+#    make defconfig ARCH=x86_64
+#    ./scripts/kconfig/merge_config.sh .config $this_file
+
+# This first section is mostly a duplicate of ndctl.git/README.md as of ndctl v81
+# Try to keep both in sync.
+
+CONFIG_X86_PMEM_LEGACY=m
+CONFIG_ZONE_DEVICE=y
+CONFIG_LIBNVDIMM=m
+CONFIG_BLK_DEV_PMEM=m
+CONFIG_BTT=y
+CONFIG_NVDIMM_PFN=y
+CONFIG_NVDIMM_DAX=y
+CONFIG_DEV_DAX_PMEM=m
+CONFIG_ENCRYPTED_KEYS=y
+CONFIG_NVDIMM_SECURITY_TEST=y
+CONFIG_STRICT_DEVMEM=y
+CONFIG_IO_STRICT_DEVMEM=y
+
+# These are required by others above but missing from
+# ndctl.git/README.md as of ndctl v81
+CONFIG_MEMORY_HOTPLUG=y
+CONFIG_MEMORY_HOTREMOVE=y
+CONFIG_TRANSPARENT_HUGEPAGE=y
+CONFIG_DAX=m
+CONFIG_DEV_DAX=m
+
+
+# These are simply missing from ndctl.git/README.md
+CONFIG_ACPI_NFIT=m
+CONFIG_NFIT_SECURITY_DEBUG=y
+CONFIG_FS_DAX=y
+CONFIG_XFS_FS=y
+CONFIG_MEMORY_FAILURE=y
+
+
+# Optimization: saves almost half the compilation time with just one
+# one-line. When making and testing changes above, comment out this line
+# to make the output of kconfig/merge_config.sh usable.
+CONFIG_DRM=n


### PR DESCRIPTION
This is enough to pass the ndctl:ndctl and ndctl:dax test suites.