### PR TITLE
mkosi.debian.default.tmpl: overdue compatibility with v15

### DIFF
--- a/mkosi.debian.default.tmpl
+++ b/mkosi.debian.default.tmpl
@@ -1,11 +1,21 @@
+# mkosi versions v15 and above need a lot more explicit Packages= like
+# "?priority(important)" and "task ssh-server".  mkosi v15 changed
+# everything, see https://github.com/systemd/mkosi/issues/1971
+
 [Content]
 Packages=
+  ?priority(important)
+  task-ssh-server
+  libnss-resolve
+  login
+  systemd-boot
   asciidoctor
   autoconf
   automake
   bash-completion
   build-essential
   cmake
+  command-not-found
   fio
   gdb
   git
@@ -26,9 +36,14 @@ Packages=
   meson
   ndctl
   openssh-client
-  openssh-server
   pkgconf
   python3
   strace
+  # Trixie needs this one for compiling ndctl, but no such package in
+  # Bookworm.  ?(exact-name ...) is used as a trick not to fail when
+  # it's missing.  We can't use mkosi [Match] yet because it's too
+  # recent.  If this grows out of control then we should switch to
+  # run_qemu.sh concatenating different files based on the revision.
+  ?exact-name(systemd-dev)
   uuid-dev
   vim


### PR DESCRIPTION
mkosi versions v15 and above need a lot more explicit Packages= like "?priority(important)" and "task ssh-server".  mkosi v15 changed everything, see https://github.com/systemd/mkosi/issues/1971

Missing packages caused a lot of issues like #168, #171, #199 and maybe others.