### PR TITLE
Use both the -drive and -device options to set rootfs image

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1858,7 +1858,9 @@ prepare_qcmd()
 		;;
 	esac
 
-	qcmd+=("-drive" "file=$_arg_rootfs,format=raw,media=disk")
+	qcmd+=("-drive" "file=$_arg_rootfs,format=raw,if=none,id=rootdisk,media=disk")
+	qcmd+=("-device" "virtio-blk,bus=pcie.0,drive=rootdisk")
+
 	if [ $_arg_direct_kernel = "on" ] && [ -n "$vmlinuz" ] && [ -n "$initrd" ]; then
 		qcmd+=("-kernel" "$vmlinuz" "-initrd" "$initrd")
 		qcmd+=("-append" "${kcmd[*]}")


### PR DESCRIPTION
In an upcoming CXL related changes to the aarch64 target QEMU, the legacy -drive
option only does not work to set rootfs image; see below Jonathan's suggestions:

```
This is a challenge to fix at qemu side because it is relying on a bunch of old behavior.  For a while now legacy -drive parameters have been split into parts that go in -drive and a separate -device entry that covers the hardware - even with that though we'd need to specify a bus as on arm64 the default for -drive is virtio-blk which ends up I connected on the pcie bus.

Note this is just as broken if you use any pxb-pcie instances as those have similar fixed assumption that you can only hang root ports off them.

I think best solution is probably to stop use the old style

-drive file=root.img,format=raw,media=disk

and switch to fully expanded virtio solution along the lines of

-drive if=none,file=root.img,format=raw,media=disk,id=hd \ -device virtio-blk,bus=pcie.0,drive=hd

which should be fine on x86 and arm64 + any other architectures we support in the future and will always bring the disk up as an RCiEP on the main pcie root complex.

Jonathan
```