### PR TITLE
Use both the -drive and -device options to set root.img

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1858,7 +1858,9 @@ prepare_qcmd()
 		;;
 	esac
 
-	qcmd+=("-drive" "file=$_arg_rootfs,format=raw,media=disk")
+	qcmd+=("-drive" "file=$_arg_rootfs,format=raw,if=none,id=rootdisk,media=disk")
+	qcmd+=("-device" "virtio-blk,bus=pcie.0,drive=rootdisk")
+
 	if [ $_arg_direct_kernel = "on" ] && [ -n "$vmlinuz" ] && [ -n "$initrd" ]; then
 		qcmd+=("-kernel" "$vmlinuz" "-initrd" "$initrd")
 		qcmd+=("-append" "${kcmd[*]}")


### PR DESCRIPTION
This is a retry of #201

With the proposed V13 of the CXL series for the QEMU upstream applied, qemu-system-aarch64
fails to boot with the legacy -drive option alone to set root.img:

qemu-system-aarch64: -drive file=root.img,format=raw,media=disk: PCI: Only PCI/PCIe bridges can be plugged into pxb-cxl

Jonathan explains this is due to on arm64 -drive is virtoi-blk by default and we need to set a bus via the -device option. Do it as Jonathan suggested in:

https://lore.kernel.org/all/20250520183109.00002730@huawei.com/

without losing backward compatibility.