### PR TITLE
run_qemu.sh: replace -drive rootfs with -blockdev + -device

### DIFF
--- a/run_qemu.sh
+++ b/run_qemu.sh
@@ -1858,7 +1858,9 @@ prepare_qcmd()
 		;;
 	esac
 
-	qcmd+=("-drive" "file=$_arg_rootfs,format=raw,media=disk")
+	qcmd+=("-blockdev" "driver=file,node-name=maindisk,filename=$_arg_rootfs")
+	qcmd+=("-device"   "virtio-blk,bus=pcie.0,drive=maindisk")
+
 	if [ $_arg_direct_kernel = "on" ] && [ -n "$vmlinuz" ] && [ -n "$initrd" ]; then
 		qcmd+=("-kernel" "$vmlinuz" "-initrd" "$initrd")
 		qcmd+=("-append" "${kcmd[*]}")


### PR DESCRIPTION
According to Itaru Kitayama in https://github.com/pmem/run_qemu/pull/210, this fixes the following error:

```
  qemu-system-aarch64: -drive file=root.img,format=raw,media=disk: PCI:
    Only PCI/PCIe bridges can be plugged into pxb-cxl
```

> Jonathan explains this is due to on arm64 -drive is virtoi-blk by
> default and we need to set a bus via the -device option. Do it as
> Jonathan suggested in:
>
> https://lore.kernel.org/linux-cxl/20250520183109.00002730@huawei.com/

From https://www.qemu.org/docs/master/system/qemu-manpage.html#hxtool-1

  The QEMU block device handling options have a long history and have gone
  through several iterations as the feature set and complexity of the
  block layer have grown. Many online guides to QEMU often reference older
  and deprecated options, which can lead to confusion.

  The most explicit way to describe disks is to use a combination of
  -device to specify the hardware device and -blockdev to describe the
  backend. The device defines what the guest sees and the backend
  describes how QEMU handles the data. It is the only guaranteed stable
  interface for describing block devices and as such is recommended for
  management tools and scripting.

  The -drive option combines the device and backend into a single command
  line option which is a more human friendly. There is however no
  interface stability guarantee although some older board models still
  need updating to work with the modern blockdev forms.

Co-developed-by: Jonathan Cameron <Jonathan.Cameron@huawei.com>
Co-developed-by: Itaru Kitayama <itaru.kitayama@fujitsu.com>
Tested-by: Itaru Kitayama <itaru.kitayama@fujitsu.com>
Signed-off-by: Marc Herbert <marc.herbert@intel.com>