### PR TITLE
.github: bump timeout again to 35 minutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -201,7 +201,7 @@ jobs:
           PATH=/usr/lib/ccache:"$PATH" \
           distro=${{ matrix.cfg.img_distro }} rev=${{ matrix.cfg.img_rel }} \
                  ndctl='${{ github.workspace }}'/ndctl \
-                 ../run_qemu/run_qemu.sh ${{ matrix.run_opts }} --no-kvm --timeout=20 --debug
+                 ../run_qemu/run_qemu.sh ${{ matrix.run_opts }} --no-kvm --timeout=35 --debug
 
       - name: upload test logs
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Sometimes github is slower, for instance this run timed out:

https://github.com/pmem/run_qemu/actions/runs/21694527708