### PR TITLE
.github: upgrade test kernel from v6.18 to v6.19

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: torvalds/linux
-          ref: v6.18
+          ref: v6.19
           path: kernel
 
       - name: set week number for ccache


### PR DESCRIPTION
Time to upgrade kernel reference.